### PR TITLE
Soft Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ In addition to the input file, this program accepts a few command-line flags:
 * `stats`: prints statistics at the end of a run instead of `sat` / `unsat`.
 * `csv`: prints statistics in CSV format instead of the default human-readable
   format. This flag has no effect if `stats` is not specified.
-* `timeout`: accepts a duration as an argument, and gives up solving after that
-  duration. If the program gives up, the returned status is `unknown`.
-  Otherwise, the status is either `sat` or `unsat`. (In other words, this solver
-  is complete.) Also, the timeout doesn't count the time taken to ingest and
-  preprocess the file.
+* `soft-timeout` and `hard-timeout`: accept a duration as an argument, and give
+  up solving after that duration. If the program gives up, the returned status
+  is `unknown`. Otherwise, the status is either `sat` or `unsat`. Also, the
+  timeout doesn't count the time taken to ingest and preprocess the file.
+  * `soft-timeout`: waits for the current iteration of the solver to complete
+    before terminating.
+  * `hard-timeout`: kills the process after the duration elapses, possibly
+    leaving the statistics in an inconsistent state.
 
 Command-line flags can also be used to specify the preprocessing and theory
 solving strategies. The available preprocessing strategies, specified with the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,11 @@ type Configuration struct {
 	// of human-readable format. This value only matters when PrintStats is set.
 	CSVStats bool
 
-	// Timeout is how long to try solving for before killing ourselves.
-	Timeout time.Duration
+	// SoftTimeout is how long to try solving before stopping instead of
+	// looping.
+	SoftTimeout time.Duration
+	// HardTimeout is how long to try solving for before killing ourselves.
+	HardTimeout time.Duration
 }
 
 // GetConfiguration looks at the command-line arguments passed to the program
@@ -70,7 +73,8 @@ func GetConfiguration() (ret Configuration) {
 	flag.StringVar(&ret.SolverName, "solver", "", "What theory to use")
 	flag.BoolVar(&ret.PrintStats, "stats", false, "Print statistics instead of problem status")
 	flag.BoolVar(&ret.CSVStats, "csv", false, "Print statistics in CSV format")
-	flag.DurationVar(&ret.Timeout, "timeout", 0, "Timeout for solving")
+	flag.DurationVar(&ret.SoftTimeout, "soft-timeout", 0, "How long to wait before stopping iterations")
+	flag.DurationVar(&ret.HardTimeout, "hard-timeout", 0, "How long to wait before killing ourselves")
 	flag.Parse()
 
 	// Now we have to handle the input file. First, check that we actually got

--- a/internal/db_test/int_test.go
+++ b/internal/db_test/int_test.go
@@ -371,7 +371,7 @@ func TestInequalitySolver(t *testing.T) {
 						t.FailNow()
 					}
 
-					if theory.Solve(&db, solver, &stats.Stats{}) != test.stat {
+					if theory.Solve(&db, solver, 0, &stats.Stats{}) != test.stat {
 						t.Errorf("wrong satisfiability")
 					}
 				})

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -13,6 +13,11 @@ type Stats struct {
 	// format. If this is unset, they are printed in human-readable format.
 	csv bool
 
+	// The Solved member reports whether the solver actually got a solution.
+	// If this is false, it means the solver timed out, either with a soft
+	// timeout or a hard timeout.
+	Solved bool
+
 	// The IngestDuration member records how long it took to parse the file and
 	// convert it to CNF.
 	IngestDuration time.Duration
@@ -51,7 +56,8 @@ func New(csv bool) Stats { return Stats{csv: csv} }
 func (stats Stats) String() string {
 	if stats.csv {
 		return fmt.Sprintf(
-			"%d,%d,%d,%d,%d,%d,%d,%d",
+			"%v,%d,%d,%d,%d,%d,%d,%d,%d",
+			stats.Solved,
 			stats.IngestDuration.Nanoseconds(),
 			stats.PreprocessDuration.Nanoseconds(),
 			stats.SATSolverDuration.Nanoseconds(),
@@ -64,6 +70,7 @@ func (stats Stats) String() string {
 	} else {
 		return fmt.Sprintf(
 			"Statistics:\n"+
+				"  Solved = %v\n"+
 				"  Ingest = %v\n"+
 				"  Preprocess = %v\n"+
 				"  SAT = %v\n"+
@@ -72,6 +79,7 @@ func (stats Stats) String() string {
 				"  Learn Overhead = %v\n"+
 				"  Calls = %d\n"+
 				"  Loops = %d",
+			stats.Solved,
 			stats.IngestDuration,
 			stats.PreprocessDuration,
 			stats.SATSolverDuration,

--- a/internal/theory/theory.go
+++ b/internal/theory/theory.go
@@ -91,6 +91,7 @@ func Solve(dbase *db.DB, thr Solver, soft_timeout time.Duration, stats *stats.St
 		stats.SATSolverDuration += time.Since(t_sat_start)
 		// If unsat, return unsat.
 		if satres == file.StatusUnsat {
+			stats.Solved = true
 			return file.StatusUnsat
 		}
 
@@ -163,6 +164,7 @@ func Solve(dbase *db.DB, thr Solver, soft_timeout time.Duration, stats *stats.St
 		stats.TheorySolverDuration += time.Since(t_thr_start)
 		// If sat, we're done
 		if err != nil {
+			stats.Solved = true
 			return file.StatusSat
 		}
 


### PR DESCRIPTION
Previously, timing out just meant killing the process, possibly leaving the statistics in an inconsistent state. To remedy this, we introduce soft timeouts. After each iteration of the (outer) solver, the timeout is checked. If too much time has elapsed, it breaks and returns `unknown`.

Additionally, the statistics now record whether solving completed. It doesn't distinguish between soft and hard timeouts - to do that look at the exit code. Zero means a soft timeout.